### PR TITLE
Better cipher suite

### DIFF
--- a/distrib/build/sources/coretree/tree/etc/httpd/conf/httpd.conf
+++ b/distrib/build/sources/coretree/tree/etc/httpd/conf/httpd.conf
@@ -173,8 +173,9 @@ ServerAdmin root@localhost
 	AddType application/x-x509-ca-cert .crt
 	AddType application/x-pkcs7-crl    .crl
 
-	SSLProtocol -ALL +TLSv1.1 +TLSv1.2
-	SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:!MEDIUM:!LOW:!SSLv2:!EXPORT
+	SSLProtocol All -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
+	SSLCipherSuite AES:!kRSA:!aNULL
+	SSLHonorCipherOrder On
 	SSLPassPhraseDialog  builtin
 	SSLSessionCache         dbm:/var/log/httpd/ssl_scache
 	SSLSessionCacheTimeout  300


### PR DESCRIPTION
There is really no point supporting TLSv1.1, libraries usually support TLSv1.0 or TLSv1.2. I inverted protocol configuration so that it's ready for TLSv1.3 as it will emerge. RC4 should not used as cipher. I included Cipher Suite that support Perfect Forward Security by not allowing anything that doesn't use Diffie-Hellman key exchange. Server should dictate cipher order.
